### PR TITLE
 Build hscim with LTS 14.12 (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 dist
 dist-*
 cabal-dev
-*.cabal
 *.o
 *.hi
 *.chi
@@ -21,8 +20,8 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+.stac-work-tmp/
 
 *~
 *.el
 \#*
-hscim.cabal

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,16 @@ addons:
     packages:
       - libgmp-dev
 
-env:
-- RESOLVER=lts-12.10
-
 before_install:
 - mkdir -p ~/.local/bin
 - export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
-- stack --resolver=$RESOLVER --no-terminal --install-ghc test --fast --only-dependencies
+- stack --no-terminal --install-ghc test --fast --only-dependencies
 
 script:
-- stack --resolver=$RESOLVER --no-terminal test --fast --haddock --no-haddock-deps
+- stack --no-terminal test --fast --haddock --no-haddock-deps
 
 notifications:  # see https://docs.travis-ci.com/user/notifications
   email: false

--- a/hscim.cabal
+++ b/hscim.cabal
@@ -1,0 +1,218 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.33.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: dacbefe6b2a13bf0be7cc0a32b675c371e2afc853228e2feb0e834c908d9aaf6
+
+name:           hscim
+version:        0.3.0
+synopsis:       ...
+description:    ...
+category:       Web
+homepage:       https://github.com/wireapp/hscim/README.md
+bug-reports:    https://github.com/wireapp/hscim/issues
+author:         Wire Swiss GmbH
+maintainer:     Wire Swiss GmbH <backend@wire.com>
+copyright:      (c) 2018 Wire Swiss GmbH
+license:        AGPL-3
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+
+source-repository head
+  type: git
+  location: https://github.com/wireapp/hscim
+
+library
+  exposed-modules:
+      Web.Scim.AttrName
+      Web.Scim.Capabilities.MetaSchema
+      Web.Scim.Capabilities.MetaSchema.Group
+      Web.Scim.Capabilities.MetaSchema.ResourceType
+      Web.Scim.Capabilities.MetaSchema.Schema
+      Web.Scim.Capabilities.MetaSchema.SPConfig
+      Web.Scim.Capabilities.MetaSchema.User
+      Web.Scim.Class.Auth
+      Web.Scim.Class.Group
+      Web.Scim.Class.User
+      Web.Scim.ContentType
+      Web.Scim.Filter
+      Web.Scim.Handler
+      Web.Scim.Schema.AuthenticationScheme
+      Web.Scim.Schema.Common
+      Web.Scim.Schema.Error
+      Web.Scim.Schema.ListResponse
+      Web.Scim.Schema.Meta
+      Web.Scim.Schema.PatchOp
+      Web.Scim.Schema.ResourceType
+      Web.Scim.Schema.Schema
+      Web.Scim.Schema.User
+      Web.Scim.Schema.User.Address
+      Web.Scim.Schema.User.Certificate
+      Web.Scim.Schema.User.Email
+      Web.Scim.Schema.User.IM
+      Web.Scim.Schema.User.Name
+      Web.Scim.Schema.User.Phone
+      Web.Scim.Schema.User.Photo
+      Web.Scim.Schema.UserTypes
+      Web.Scim.Server
+      Web.Scim.Server.Mock
+      Web.Scim.Test.Acceptance
+      Web.Scim.Test.Util
+  other-modules:
+      Paths_hscim
+  hs-source-dirs:
+      src
+  default-extensions: ConstraintKinds DataKinds DeriveFunctor DeriveGeneric FlexibleContexts FlexibleInstances KindSignatures LambdaCase MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  ghc-options: -Wall -Werror
+  build-depends:
+      aeson >=1.4.5 && <1.5
+    , aeson-qq >=0.8.2 && <0.9
+    , attoparsec >=0.13.2 && <0.14
+    , base >=4.12 && <4.13
+    , bytestring >=0.10.8 && <0.11
+    , email-validate >=2.3.2 && <2.4
+    , errors >=2.3.0 && <2.4
+    , hashable >=1.2.7 && <1.4
+    , hedgehog >=1.0.1 && <1.1
+    , hspec >=2.7.1 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , hspec-wai >=0.9.2 && <0.10
+    , http-api-data >=0.4.1 && <0.5
+    , http-media >=0.8.0 && <0.9
+    , http-types >=0.12.3 && <0.13
+    , hw-hspec-hedgehog >=0.1.0 && <0.2
+    , list-t >=1.0.4 && <1.1
+    , microlens >=0.4.10 && <0.5
+    , mmorph >=1.1.3 && <1.2
+    , mtl >=2.2.2 && <2.3
+    , network-uri >=2.6.1 && <2.7
+    , network-uri-static >=0.1.2 && <0.2
+    , scientific >=0.3.6 && <0.4
+    , servant >=0.16.2 && <0.17
+    , servant-server >=0.16.2 && <0.17
+    , stm >=2.5.0 && <2.6
+    , stm-containers >=1.1.0 && <1.2
+    , template-haskell >=2.14.0 && <2.15
+    , text >=1.2.3 && <1.3
+    , time >=1.8.0 && <1.9
+    , unordered-containers >=0.2.10 && <0.3
+    , uuid >=1.3.13 && <1.4
+    , vector >=0.12.0 && <0.13
+    , wai >=3.2.2 && <3.3
+    , wai-extra >=3.0.28 && <3.1
+    , wai-logger >=2.3.5 && <2.4
+    , warp >=3.2.28 && <3.4
+  default-language: Haskell2010
+
+executable hscim-server
+  main-is: Main.hs
+  other-modules:
+      Paths_hscim
+  hs-source-dirs:
+      server
+  default-extensions: ConstraintKinds DataKinds DeriveFunctor DeriveGeneric FlexibleContexts FlexibleInstances KindSignatures LambdaCase MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson >=1.4.5 && <1.5
+    , aeson-qq >=0.8.2 && <0.9
+    , attoparsec >=0.13.2 && <0.14
+    , base >=4.12 && <4.13
+    , bytestring >=0.10.8 && <0.11
+    , email-validate >=2.3.2 && <2.4
+    , errors >=2.3.0 && <2.4
+    , hashable >=1.2.7 && <1.4
+    , hedgehog >=1.0.1 && <1.1
+    , hscim
+    , hspec >=2.7.1 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , hspec-wai >=0.9.2 && <0.10
+    , http-api-data >=0.4.1 && <0.5
+    , http-media >=0.8.0 && <0.9
+    , http-types >=0.12.3 && <0.13
+    , hw-hspec-hedgehog >=0.1.0 && <0.2
+    , list-t >=1.0.4 && <1.1
+    , microlens >=0.4.10 && <0.5
+    , mmorph >=1.1.3 && <1.2
+    , mtl >=2.2.2 && <2.3
+    , network-uri >=2.6.1 && <2.7
+    , network-uri-static >=0.1.2 && <0.2
+    , scientific >=0.3.6 && <0.4
+    , servant >=0.16.2 && <0.17
+    , servant-server >=0.16.2 && <0.17
+    , stm >=2.5.0 && <2.6
+    , stm-containers >=1.1.0 && <1.2
+    , template-haskell >=2.14.0 && <2.15
+    , text >=1.2.3 && <1.3
+    , time >=1.8.0 && <1.9
+    , unordered-containers >=0.2.10 && <0.3
+    , uuid >=1.3.13 && <1.4
+    , vector >=0.12.0 && <0.13
+    , wai >=3.2.2 && <3.3
+    , wai-extra >=3.0.28 && <3.1
+    , wai-logger >=2.3.5 && <2.4
+    , warp >=3.2.28 && <3.4
+  default-language: Haskell2010
+
+test-suite spec
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Test.AcceptanceSpec
+      Test.Capabilities.MetaSchemaSpec
+      Test.Class.AuthSpec
+      Test.Class.GroupSpec
+      Test.Class.UserSpec
+      Test.FilterSpec
+      Test.Schema.PatchOpSpec
+      Test.Schema.UserSpec
+      Paths_hscim
+  hs-source-dirs:
+      test
+  default-extensions: ConstraintKinds DataKinds DeriveFunctor DeriveGeneric FlexibleContexts FlexibleInstances KindSignatures LambdaCase MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeApplications TypeFamilies TypeOperators TypeSynonymInstances
+  ghc-options: -Wall -Werror -threaded -rtsopts -with-rtsopts=-N
+  build-tool-depends:
+      hspec-discover:hspec-discover
+  build-depends:
+      aeson >=1.4.5 && <1.5
+    , aeson-qq >=0.8.2 && <0.9
+    , attoparsec >=0.13.2 && <0.14
+    , base >=4.12 && <4.13
+    , bytestring >=0.10.8 && <0.11
+    , email-validate >=2.3.2 && <2.4
+    , errors >=2.3.0 && <2.4
+    , hashable >=1.2.7 && <1.4
+    , hedgehog >=1.0.1 && <1.1
+    , hscim
+    , hspec >=2.7.1 && <2.8
+    , hspec-expectations >=0.8.2 && <0.9
+    , hspec-wai >=0.9.2 && <0.10
+    , http-api-data >=0.4.1 && <0.5
+    , http-media >=0.8.0 && <0.9
+    , http-types >=0.12.3 && <0.13
+    , hw-hspec-hedgehog >=0.1.0 && <0.2
+    , list-t >=1.0.4 && <1.1
+    , microlens >=0.4.10 && <0.5
+    , mmorph >=1.1.3 && <1.2
+    , mtl >=2.2.2 && <2.3
+    , network-uri >=2.6.1 && <2.7
+    , network-uri-static >=0.1.2 && <0.2
+    , scientific >=0.3.6 && <0.4
+    , servant >=0.16.2 && <0.17
+    , servant-server >=0.16.2 && <0.17
+    , stm >=2.5.0 && <2.6
+    , stm-containers >=1.1.0 && <1.2
+    , template-haskell >=2.14.0 && <2.15
+    , text >=1.2.3 && <1.3
+    , time >=1.8.0 && <1.9
+    , unordered-containers >=0.2.10 && <0.3
+    , uuid >=1.3.13 && <1.4
+    , vector >=0.12.0 && <0.13
+    , wai >=3.2.2 && <3.3
+    , wai-extra >=3.0.28 && <3.1
+    , wai-logger >=2.3.5 && <2.4
+    , warp >=3.2.28 && <3.4
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hscim
-version:             0.2
+version:             0.3.0
 synopsis:            ...
 description:         ...
 homepage:            https://github.com/wireapp/hscim/README.md
@@ -33,45 +33,45 @@ default-extensions:
 extra-source-files:
   - README.md
 
+
 dependencies:
-  - aeson
-  - aeson-qq
-  - attoparsec
-  - base >= 4.11 && < 5
-  - bytestring
-  - email-validate
-  - errors
-  - hashable
-  - hedgehog
-  - hspec
-  - hspec-expectations
-  - hspec-wai
-  - http-api-data
-  - http-media
-  - http-types
-  - hw-hspec-hedgehog
-  - list-t
-  - microlens
-  - mmorph
-  - mtl
-  - network-uri
-  - network-uri-static >= 0.1.1.0
-  - scientific
-  - servant
-  - servant-server
-  - servant-server >= 0.14.1
-  - stm
-  - stm-containers
-  - template-haskell
-  - text
-  - time
-  - unordered-containers
-  - uuid
-  - vector
-  - wai
-  - wai-extra
-  - wai-logger
-  - warp
+  -  aeson                >= 1.4.5 && < 1.5
+  -  attoparsec           >= 0.13.2 && < 0.14
+  -  bytestring           >= 0.10.8 && < 0.11
+  -  base                 >= 4.12  && < 4.13
+  -  scientific           >= 0.3.6 && < 0.4
+  -  hashable             >= 1.2.7 && < 1.4
+  -  text                 >= 1.2.3 && < 1.3
+  -  time                 >= 1.8.0 && < 1.9
+  -  template-haskell     >= 2.14.0 && < 2.15
+  -  unordered-containers >= 0.2.10 && < 0.3
+  -  vector               >= 0.12.0 && < 0.13
+  -  aeson-qq             >= 0.8.2 && < 0.9
+  -  mtl                  >= 2.2.2 && < 2.3
+  -  email-validate       >= 2.3.2 && < 2.4
+  -  errors               >= 2.3.0 && < 2.4
+  -  stm                  >= 2.5.0 && < 2.6
+  -  hedgehog             >= 1.0.1 && < 1.1
+  -  mmorph               >= 1.1.3 && < 1.2
+  -  hspec                >= 2.7.1 && < 2.8
+  -  hspec-wai            >= 0.9.2 && < 0.10
+  -  hspec-expectations   >= 0.8.2 && < 0.9
+  -  http-types           >= 0.12.3 && < 0.13
+  -  wai                  >= 3.2.2 && < 3.3
+  -  wai-extra            >= 3.0.28 && < 3.1
+  -  wai-logger           >= 2.3.5 && < 2.4
+  -  http-api-data        >= 0.4.1 && < 0.5
+  -  http-media           >= 0.8.0 && < 0.9
+  -  hw-hspec-hedgehog    >= 0.1.0 && < 0.2
+  -  list-t               >= 1.0.4 && < 1.1
+  -  microlens            >= 0.4.10 && < 0.5
+  -  network-uri          >= 2.6.1 && < 2.7
+  -  network-uri-static   >= 0.1.2 && < 0.2
+  -  servant              >= 0.16.2 && < 0.17
+  -  servant-server       >= 0.16.2 && < 0.17
+  -  warp                 >= 3.2.28 && < 3.4
+  -  stm-containers       >= 1.1.0 && < 1.2
+  -  uuid                 >= 1.3.13 && < 1.4
 
 ghc-options: -Wall -Werror
 
@@ -85,7 +85,6 @@ executables:
     source-dirs: server
     dependencies:
       - hscim
-      - warp
 
 tests:
   spec:
@@ -93,27 +92,7 @@ tests:
     ghc-options: -threaded -rtsopts -with-rtsopts=-N
     source-dirs:
       - test
+    build-tools:
+      - hspec-discover:hspec-discover
     dependencies:
       - hscim
-      - aeson
-      - aeson-qq
-      - base
-      - bytestring
-      - containers
-      - hedgehog
-      - hspec
-      - hspec-discover
-      - hspec-expectations
-      - hspec-wai
-      - http-types
-      - hw-hspec-hedgehog
-      - mtl
-      - servant-server
-      - stm-containers
-      - template-haskell
-      - text
-      - time
-      - vector
-      - wai-extra
-      - wai-logger
-      - warp

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -16,7 +16,7 @@ import           Web.Scim.Capabilities.MetaSchema as MetaSchema
 import           Data.Time
 import           Network.Wai.Handler.Warp
 import           Network.URI.Static
-import qualified STMContainers.Map as STMMap
+import qualified StmContainers.Map as STMMap
 import           Control.Monad.STM (atomically)
 import           Text.Email.Validate
 

--- a/src/Web/Scim/Schema/Error.hs
+++ b/src/Web/Scim/Schema/Error.hs
@@ -15,7 +15,7 @@ module Web.Scim.Schema.Error
   , serverError
 
   -- * Servant interoperability
-  , scimToServantErr
+  , scimToServerError
   ) where
 
 import Data.Text (Text, pack)
@@ -23,7 +23,7 @@ import Data.Aeson hiding (Error)
 import Control.Exception
 import Web.Scim.Schema.Common
 import Web.Scim.Schema.Schema
-import Servant (ServantErr (..))
+import Servant (ServerError (..))
 
 import GHC.Generics (Generic)
 
@@ -153,9 +153,9 @@ serverError details =
 
 -- | Convert a SCIM 'Error' to a Servant one by encoding it with the
 -- appropriate headers.
-scimToServantErr :: ScimError -> ServantErr
-scimToServantErr err =
-  ServantErr
+scimToServerError :: ScimError -> ServerError
+scimToServerError err =
+  ServerError
     { errHTTPCode = unStatus (status err)
     , errReasonPhrase = reasonPhrase (status err)
     , errBody = encode err

--- a/src/Web/Scim/Schema/Schema.hs
+++ b/src/Web/Scim/Schema/Schema.hs
@@ -6,11 +6,11 @@ import           Web.Scim.Capabilities.MetaSchema.Group
 import           Web.Scim.Capabilities.MetaSchema.Schema
 import           Web.Scim.Capabilities.MetaSchema.ResourceType
 
-import           Data.Aeson (FromJSON, parseJSON, toJSON, ToJSON, withText, Value)
-import           Data.Attoparsec.ByteString (Parser)
-import qualified Data.Attoparsec.ByteString.Char8 as Parser
-import           Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import           Data.Text (Text)
+import           Data.Aeson (FromJSON, parseJSON, toJSON, ToJSON, withText, Value)
+import Data.Text.Encoding (decodeUtf8, encodeUtf8)
+import Data.Attoparsec.ByteString (Parser)
+import qualified Data.Attoparsec.ByteString.Char8 as Parser
 
 -- | All schemas that we support.
 data Schema = User20

--- a/src/Web/Scim/Server/Mock.hs
+++ b/src/Web/Scim/Server/Mock.hs
@@ -21,7 +21,7 @@ import           Data.Time.Clock
 import           Data.Time.Calendar
 import           GHC.Exts (sortWith)
 import           ListT
-import qualified STMContainers.Map as STMMap
+import qualified StmContainers.Map as STMMap
 import           Text.Read (readMaybe)
 import           Web.Scim.Filter (Filter(..), CompValue(..), AttrPath(..), compareStr)
 import           Web.Scim.Schema.User
@@ -79,7 +79,7 @@ instance UserTypes Mock where
 instance UserDB Mock TestServer where
   getUsers () mbFilter = do
     m <- userDB <$> ask
-    users <- liftSTM $ ListT.toList $ STMMap.stream m
+    users <- liftSTM $ ListT.toList $ STMMap.listT m
     let check user = case mbFilter of
           Nothing -> pure True
           Just filter_ -> do
@@ -130,7 +130,7 @@ instance GroupTypes Mock where
 instance GroupDB Mock TestServer where
   getGroups () = do
     m <- groupDB <$> ask
-    groups <- liftSTM $ ListT.toList $ STMMap.stream m
+    groups <- liftSTM $ ListT.toList $ STMMap.listT m
     return $ fromList . sortWith (Common.id . thing) $ snd <$> groups
 
   getGroup () gid = do
@@ -200,7 +200,7 @@ createMeta rType = Meta
 nt :: TestStorage -> ScimHandler TestServer a -> Handler a
 nt storage =
   flip runReaderT storage .
-  fromScimHandler (lift . throwError . scimToServantErr)
+  fromScimHandler (lift . throwError . scimToServerError)
 
 
 -- | Check whether a user satisfies the filter.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,15 @@
-resolver: lts-12.10
-compiler: ghc-8.4.4
+resolver: lts-14.12
 
 packages:
 - .
 
 extra-deps:
-- network-uri-static-0.1.1.0
+- network-uri-static-0.1.2.1@sha256:7e1ca4358b319ac2db6514d0e0beb073c296789eeef9cebd89cc9517618fbfe8,1724
+- stm-containers-1.1.0.4@sha256:f83a683357b6e3b1dda3e70d2077a37224ed534df1f74c4e11f3f6daa7945c5b,3248
+- stm-hamt-1.2.0.4@sha256:7957497c022554b7599e790696d1a3e56359ad99e5da36a251894c626ca1f60a,3970
+- primitive-0.7.0.0@sha256:ee352d97cc390d8513530029a2213a95c179a66c406906b18d03702c1d9ab8e5,3416
+- primitive-extras-0.8@sha256:fca0310150496867f5b9421fe1541ecda87fae17eae44885a29f9c52dd00c8ff,2963
+- primitive-unlifted-0.1.2.0@sha256:9c3df73af54ed19fb3f4874da19334863cc414b22e578e27b5f52beeac4a60dd,1360
 
 nix:
   packages:

--- a/test/Test/Class/AuthSpec.hs
+++ b/test/Test/Class/AuthSpec.hs
@@ -11,7 +11,7 @@ import           Test.Hspec
 import           Test.Hspec.Wai      hiding (post, put, patch)
 import           Network.HTTP.Types.Header
 import           Network.HTTP.Types.Method (methodGet)
-import qualified STMContainers.Map   as STMMap
+import qualified StmContainers.Map   as STMMap
 
 testStorage :: IO TestStorage
 testStorage = TestStorage <$> STMMap.newIO <*> STMMap.newIO


### PR DESCRIPTION
we had to revert #40 to make https://github.com/wireapp/wire-server/pull/931 work.

this can be merged once we're on lts-14.12 in wire-server.